### PR TITLE
Redesign: Linear polish + amber accent, reading-first layout

### DIFF
--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -1,3 +1,3 @@
-<div class='flex flex-col gap-2 p-4 md:p-6 xl:max-h-xl'>
+<div class='flex flex-col gap-2'>
   <slot />
 </div>

--- a/src/components/FooterNav.astro
+++ b/src/components/FooterNav.astro
@@ -6,16 +6,53 @@ import { ContactDialog } from './Contact/ContactDialog';
 const pathName = `/${Astro.request.url.split('/')[3]}`;
 ---
 
-<div
-  class='sm:hidden flex sticky bottom-0 gap-6 justify-center items-center w-screen h-16 bg-background/90 backdrop-blur border-t border-zinc-200 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 overflow-x-scroll'
+<nav
+  id='mobile-nav'
+  class='sm:hidden fixed bottom-0 left-0 right-0 z-50 flex justify-around items-center w-full h-14 px-2 bg-background/90 backdrop-blur-md border-t border-zinc-200 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 transition-transform duration-300'
 >
   {
-    navItems.map(({ href, name, popOut, Icon }, idx) => (
-      <a target={popOut ? '_blank' : '_self'} href={href}>
-        <Icon className='w-6 h-6' />
+    navItems.map(({ href, name, popOut, Icon }) => (
+      <a
+        target={popOut ? '_blank' : '_self'}
+        href={href}
+        class={`flex flex-col items-center gap-0.5 p-2 rounded-md transition-colors ${
+          pathName === href
+            ? 'text-zinc-900 dark:text-zinc-100'
+            : 'hover:text-zinc-700 dark:hover:text-zinc-300'
+        }`}
+        aria-label={name}
+      >
+        <Icon className='w-5 h-5' />
       </a>
     ))
   }
   <ContactDialog client:only='react' />
   <ThemeToggle client:only='react' />
-</div>
+</nav>
+
+<!-- Spacer so content doesn't sit behind the fixed nav -->
+<div class='sm:hidden h-14'></div>
+
+<script>
+  const nav = document.getElementById('mobile-nav');
+  let lastScrollY = window.scrollY;
+  let ticking = false;
+
+  window.addEventListener('scroll', () => {
+    if (!ticking) {
+      window.requestAnimationFrame(() => {
+        const currentScrollY = window.scrollY;
+        if (currentScrollY > lastScrollY && currentScrollY > 60) {
+          // Scrolling down — hide
+          nav?.classList.add('translate-y-full');
+        } else {
+          // Scrolling up — show
+          nav?.classList.remove('translate-y-full');
+        }
+        lastScrollY = currentScrollY;
+        ticking = false;
+      });
+      ticking = true;
+    }
+  }, { passive: true });
+</script>

--- a/src/components/FooterNav.astro
+++ b/src/components/FooterNav.astro
@@ -7,7 +7,7 @@ const pathName = `/${Astro.request.url.split('/')[3]}`;
 ---
 
 <div
-  class='sm:hidden flex sticky bottom-0 gap-6 justify-center items-center w-screen h-16 bg-zinc-100 text-zinc-600 overflow-x-scroll dark:text-zinc-400 dark:bg-zinc-800'
+  class='sm:hidden flex sticky bottom-0 gap-6 justify-center items-center w-screen h-16 bg-background/90 backdrop-blur border-t border-zinc-200 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 overflow-x-scroll'
 >
   {
     navItems.map(({ href, name, popOut, Icon }, idx) => (

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,6 +6,6 @@ interface Props {
 const { textAlign } = Astro.props as Props;
 ---
 
-<header class={`text-${textAlign} mt-4 md:mt-8`}>
+<header class={`text-${textAlign} mt-8 md:mt-12 px-8 md:px-12 max-w-3xl w-full mx-auto`}>
   <slot />
 </header>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,152 +1,54 @@
 import { motion } from 'framer-motion';
-import { Button } from './ui/button';
 
 export const Hero = () => {
   return (
-    <div className='flex flex-col p-8 gap-6 h-[25rem] w-full dark:bg-zinc-900 bg-gray-200/75  dark:bg-dot-white/[0.2] bg-dot-black/[0.2] relative items-center justify-center'>
-      {/* Radial gradient for the container to give a faded look */}
-      <div className='absolute pointer-events-none inset-0 flex items-center justify-center dark:bg-zinc-950 bg-white [mask-image:radial-gradient(ellipse_at_center,transparent_70%,black)]'></div>
-      <motion.img
-        className='rounded-full inline-block h-32 w-32'
-        src='https://avatars.githubusercontent.com/u/42482170?v=4'
-        width={128}
-        height={128}
-        initial={{ y: -10, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        alt='An avatar of David Neuman'
-      />
-      <motion.h1
-        initial={{ y: -10, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.2 }}
-        className='text-gray-900 dark:text-gray-300 text-4xl sm:text-7xl font-bold relative'
+    <div className='w-full px-8 py-16 md:py-20 max-w-3xl'>
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className='flex items-center gap-4 mb-8'
       >
-        Hi, I'm David
+        <img
+          className='rounded-full h-12 w-12'
+          src='https://avatars.githubusercontent.com/u/42482170?v=4'
+          width={48}
+          height={48}
+          alt='An avatar of David Neuman'
+        />
+        <div>
+          <p className='text-xs font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500'>
+            David Neuman
+          </p>
+        </div>
+      </motion.div>
+
+      <motion.h1
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1, duration: 0.4 }}
+        className='text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 leading-tight mb-4'
+      >
+        Engineer. Writer.{' '}
+        <span className='relative inline-block'>
+          Building
+          <span
+            className='absolute -bottom-1 left-0 right-0 h-[3px] rounded-full'
+            style={{ backgroundColor: 'hsl(var(--brand))' }}
+          />
+        </span>{' '}
+        for the agentic era.
       </motion.h1>
 
-      <motion.div
-        initial={{ y: -10, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.4 }}
-        className='flex flex-col gap-2 text-md md:text-lg font- max-w-lg text-center text-gray-700 dark:text-gray-400'
+      <motion.p
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2, duration: 0.4 }}
+        className='text-base md:text-lg text-zinc-500 dark:text-zinc-400 leading-relaxed max-w-xl'
       >
-        <p className='flex flex-col md:inline'>
-          I'm a product-minded engineer learning{' '}
-          <span className='border border-zinc-950 dark:border-gray-700 border-solid px-4 py-2 relative self-center'>
-            <span>design.</span>
-            <div className='absolute top-[-4px] -left-[4px] p-0 bg-zinc-700 dark:bg-zinc-50 w-2 aspect-square rounded-full ' />
-            <div className='absolute bottom-[-4px] -left-[4px] p-0 bg-zinc-700 dark:bg-zinc-50 w-2 aspect-square rounded-full ' />
-            <div className='absolute top-[-4px] -right-[4px] p-0 bg-zinc-700 dark:bg-zinc-50 w-2 aspect-square rounded-full ' />
-            <div className='absolute bottom-[-4px] -right-[4px] p-0 bg-zinc-700 dark:bg-zinc-50 w-2 aspect-square rounded-full ' />
-          </span>
-        </p>
-        <p>Building for the web and sharing what I learn along the way.</p>
-      </motion.div>
-      <motion.div
-        initial={{ y: -10, opacity: 0 }}
-        animate={{ y: 0, opacity: 1 }}
-        transition={{ delay: 0.6 }}
-        className='flex gap-4 justify-center'
-      >
-        <svg
-          className='h-6 w-6'
-          viewBox='0 0 256 228'
-          width='256'
-          height='228'
-          xmlns='http://www.w3.org/2000/svg'
-          preserveAspectRatio='xMidYMid'
-        >
-          <path
-            d='M210.483 73.824a171.49 171.49 0 0 0-8.24-2.597c.465-1.9.893-3.777 1.273-5.621 6.238-30.281 2.16-54.676-11.769-62.708-13.355-7.7-35.196.329-57.254 19.526a171.23 171.23 0 0 0-6.375 5.848 155.866 155.866 0 0 0-4.241-3.917C100.759 3.829 77.587-4.822 63.673 3.233 50.33 10.957 46.379 33.89 51.995 62.588a170.974 170.974 0 0 0 1.892 8.48c-3.28.932-6.445 1.924-9.474 2.98C17.309 83.498 0 98.307 0 113.668c0 15.865 18.582 31.778 46.812 41.427a145.52 145.52 0 0 0 6.921 2.165 167.467 167.467 0 0 0-2.01 9.138c-5.354 28.2-1.173 50.591 12.134 58.266 13.744 7.926 36.812-.22 59.273-19.855a145.567 145.567 0 0 0 5.342-4.923 168.064 168.064 0 0 0 6.92 6.314c21.758 18.722 43.246 26.282 56.54 18.586 13.731-7.949 18.194-32.003 12.4-61.268a145.016 145.016 0 0 0-1.535-6.842c1.62-.48 3.21-.974 4.76-1.488 29.348-9.723 48.443-25.443 48.443-41.52 0-15.417-17.868-30.326-45.517-39.844Zm-6.365 70.984c-1.4.463-2.836.91-4.3 1.345-3.24-10.257-7.612-21.163-12.963-32.432 5.106-11 9.31-21.767 12.459-31.957 2.619.758 5.16 1.557 7.61 2.4 23.69 8.156 38.14 20.213 38.14 29.504 0 9.896-15.606 22.743-40.946 31.14Zm-10.514 20.834c2.562 12.94 2.927 24.64 1.23 33.787-1.524 8.219-4.59 13.698-8.382 15.893-8.067 4.67-25.32-1.4-43.927-17.412a156.726 156.726 0 0 1-6.437-5.87c7.214-7.889 14.423-17.06 21.459-27.246 12.376-1.098 24.068-2.894 34.671-5.345.522 2.107.986 4.173 1.386 6.193ZM87.276 214.515c-7.882 2.783-14.16 2.863-17.955.675-8.075-4.657-11.432-22.636-6.853-46.752a156.923 156.923 0 0 1 1.869-8.499c10.486 2.32 22.093 3.988 34.498 4.994 7.084 9.967 14.501 19.128 21.976 27.15a134.668 134.668 0 0 1-4.877 4.492c-9.933 8.682-19.886 14.842-28.658 17.94ZM50.35 144.747c-12.483-4.267-22.792-9.812-29.858-15.863-6.35-5.437-9.555-10.836-9.555-15.216 0-9.322 13.897-21.212 37.076-29.293 2.813-.98 5.757-1.905 8.812-2.773 3.204 10.42 7.406 21.315 12.477 32.332-5.137 11.18-9.399 22.249-12.634 32.792a134.718 134.718 0 0 1-6.318-1.979Zm12.378-84.26c-4.811-24.587-1.616-43.134 6.425-47.789 8.564-4.958 27.502 2.111 47.463 19.835a144.318 144.318 0 0 1 3.841 3.545c-7.438 7.987-14.787 17.08-21.808 26.988-12.04 1.116-23.565 2.908-34.161 5.309a160.342 160.342 0 0 1-1.76-7.887Zm110.427 27.268a347.8 347.8 0 0 0-7.785-12.803c8.168 1.033 15.994 2.404 23.343 4.08-2.206 7.072-4.956 14.465-8.193 22.045a381.151 381.151 0 0 0-7.365-13.322Zm-45.032-43.861c5.044 5.465 10.096 11.566 15.065 18.186a322.04 322.04 0 0 0-30.257-.006c4.974-6.559 10.069-12.652 15.192-18.18ZM82.802 87.83a323.167 323.167 0 0 0-7.227 13.238c-3.184-7.553-5.909-14.98-8.134-22.152 7.304-1.634 15.093-2.97 23.209-3.984a321.524 321.524 0 0 0-7.848 12.897Zm8.081 65.352c-8.385-.936-16.291-2.203-23.593-3.793 2.26-7.3 5.045-14.885 8.298-22.6a321.187 321.187 0 0 0 7.257 13.246c2.594 4.48 5.28 8.868 8.038 13.147Zm37.542 31.03c-5.184-5.592-10.354-11.779-15.403-18.433 4.902.192 9.899.29 14.978.29 5.218 0 10.376-.117 15.453-.343-4.985 6.774-10.018 12.97-15.028 18.486Zm52.198-57.817c3.422 7.8 6.306 15.345 8.596 22.52-7.422 1.694-15.436 3.058-23.88 4.071a382.417 382.417 0 0 0 7.859-13.026 347.403 347.403 0 0 0 7.425-13.565Zm-16.898 8.101a358.557 358.557 0 0 1-12.281 19.815 329.4 329.4 0 0 1-23.444.823c-7.967 0-15.716-.248-23.178-.732a310.202 310.202 0 0 1-12.513-19.846h.001a307.41 307.41 0 0 1-10.923-20.627 310.278 310.278 0 0 1 10.89-20.637l-.001.001a307.318 307.318 0 0 1 12.413-19.761c7.613-.576 15.42-.876 23.31-.876H128c7.926 0 15.743.303 23.354.883a329.357 329.357 0 0 1 12.335 19.695 358.489 358.489 0 0 1 11.036 20.54 329.472 329.472 0 0 1-11 20.722Zm22.56-122.124c8.572 4.944 11.906 24.881 6.52 51.026-.344 1.668-.73 3.367-1.15 5.09-10.622-2.452-22.155-4.275-34.23-5.408-7.034-10.017-14.323-19.124-21.64-27.008a160.789 160.789 0 0 1 5.888-5.4c18.9-16.447 36.564-22.941 44.612-18.3ZM128 90.808c12.625 0 22.86 10.235 22.86 22.86s-10.235 22.86-22.86 22.86-22.86-10.235-22.86-22.86 10.235-22.86 22.86-22.86Z'
-            fill='#00D8FF'
-          />
-        </svg>
-        <svg
-          className='h-6 w-6'
-          viewBox='0 0 256 256'
-          xmlns='http://www.w3.org/2000/svg'
-          xmlnsXlink='http://www.w3.org/1999/xlink'
-          width='256'
-          height='256'
-          preserveAspectRatio='xMidYMid'
-        >
-          <defs>
-            <linearGradient
-              id='c'
-              x1='55.633%'
-              x2='83.228%'
-              y1='56.385%'
-              y2='96.08%'
-            >
-              <stop offset='0%' stop-color='#FFF' />
-              <stop offset='100%' stop-color='#FFF' stop-opacity='0' />
-            </linearGradient>
-            <linearGradient id='d' x1='50%' x2='49.953%' y1='0%' y2='73.438%'>
-              <stop offset='0%' stop-color='#FFF' />
-              <stop offset='100%' stop-color='#FFF' stop-opacity='0' />
-            </linearGradient>
-            <circle id='a' cx='128' cy='128' r='128' />
-          </defs>
-          <mask id='b' fill='#fff'>
-            <use xlinkHref='#a' />
-          </mask>
-          <g mask='url(#b)'>
-            <circle cx='128' cy='128' r='128' />
-            <path
-              fill='url(#c)'
-              d='M212.634 224.028 98.335 76.8H76.8v102.357h17.228V98.68L199.11 234.446a128.433 128.433 0 0 0 13.524-10.418Z'
-            />
-            <path fill='url(#d)' d='M163.556 76.8h17.067v102.4h-17.067z' />
-          </g>
-        </svg>
-        <svg
-          className='h-6 w-6'
-          viewBox='0 0 256 366'
-          xmlns='http://www.w3.org/2000/svg'
-          width='256'
-          height='366'
-          preserveAspectRatio='xMidYMid'
-        >
-          <path
-            fill='currentColor'
-            d='M182.022 9.147c2.982 3.702 4.502 8.697 7.543 18.687L256 246.074a276.467 276.467 0 0 0-79.426-26.891L133.318 73.008a5.63 5.63 0 0 0-10.802.017L79.784 219.11A276.453 276.453 0 0 0 0 246.04L66.76 27.783c3.051-9.972 4.577-14.959 7.559-18.654a24.541 24.541 0 0 1 9.946-7.358C88.67 0 93.885 0 104.314 0h47.683c10.443 0 15.664 0 20.074 1.774a24.545 24.545 0 0 1 9.95 7.373Z'
-          />
-          <path
-            fill='#FF5D01'
-            d='M189.972 256.46c-10.952 9.364-32.812 15.751-57.992 15.751-30.904 0-56.807-9.621-63.68-22.56-2.458 7.415-3.009 15.903-3.009 21.324 0 0-1.619 26.623 16.898 45.14 0-9.615 7.795-17.41 17.41-17.41 16.48 0 16.46 14.378 16.446 26.043l-.001 1.041c0 17.705 10.82 32.883 26.21 39.28a35.685 35.685 0 0 1-3.588-15.647c0-16.886 9.913-23.173 21.435-30.48 9.167-5.814 19.353-12.274 26.372-25.232a47.588 47.588 0 0 0 5.742-22.735c0-5.06-.786-9.938-2.243-14.516Z'
-          />
-        </svg>
-        <svg
-          className='h-6 w-6 fill-current'
-          viewBox='0 0 256 154'
-          width='256'
-          height='154'
-          xmlns='http://www.w3.org/2000/svg'
-          preserveAspectRatio='xMidYMid'
-        >
-          <defs>
-            <linearGradient x1='-2.778%' y1='32%' x2='100%' y2='67.556%' id='a'>
-              <stop stop-color='#2298BD' offset='0%' />
-              <stop stop-color='#0ED7B5' offset='100%' />
-            </linearGradient>
-          </defs>
-          <path
-            d='M128 0C93.867 0 72.533 17.067 64 51.2 76.8 34.133 91.733 27.733 108.8 32c9.737 2.434 16.697 9.499 24.401 17.318C145.751 62.057 160.275 76.8 192 76.8c34.133 0 55.467-17.067 64-51.2-12.8 17.067-27.733 23.467-44.8 19.2-9.737-2.434-16.697-9.499-24.401-17.318C174.249 14.743 159.725 0 128 0ZM64 76.8C29.867 76.8 8.533 93.867 0 128c12.8-17.067 27.733-23.467 44.8-19.2 9.737 2.434 16.697 9.499 24.401 17.318C81.751 138.857 96.275 153.6 128 153.6c34.133 0 55.467-17.067 64-51.2-12.8 17.067-27.733 23.467-44.8 19.2-9.737-2.434-16.697-9.499-24.401-17.318C110.249 91.543 95.725 76.8 64 76.8Z'
-            fill='#0ED7B5'
-          />
-        </svg>
-        <svg
-          className='h-6 w-6'
-          xmlns='http://www.w3.org/2000/svg'
-          fill='currentColor'
-          viewBox='4 0 17 25'
-        >
-          <path
-            d='M12 25a8 8 0 1 1 0-16v16zM12 0H4v8h8V0zM17 8a4 4 0 1 0 0-8 4 4 0 0 0 0 8z'
-            fill='currentColor'
-          />
-        </svg>
-      </motion.div>
+        Writing about agentic engineering and how engineers as humans can thrive
+        in an era of AI. Sharing what I learn along the way.
+      </motion.p>
     </div>
   );
 };

--- a/src/components/Pill/Pill.astro
+++ b/src/components/Pill/Pill.astro
@@ -1,8 +1,8 @@
-<div
-  class='cursor-pointer w-max text-[11px] font-mono rounded-full border px-2.5 py-0.5 uppercase tracking-wide
+<span
+  class='inline-flex items-center cursor-pointer w-max text-[11px] font-mono rounded-full border px-2.5 py-0.5 uppercase tracking-wide
     bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100
     dark:bg-amber-950/30 dark:text-amber-400 dark:border-amber-800/50 dark:hover:bg-amber-950/50
     transition-colors'
 >
   <slot />
-</div>
+</span>

--- a/src/components/Pill/Pill.astro
+++ b/src/components/Pill/Pill.astro
@@ -1,5 +1,8 @@
 <div
-  class='cursor-pointer w-max text-xs rounded-full bg-blue-50 px-3 py-1 uppercase font-semibold hover:bg-blue-100 dark:bg-blue-900 dark:hover:bg-blue-800'
+  class='cursor-pointer w-max text-[11px] font-mono rounded-full border px-2.5 py-0.5 uppercase tracking-wide
+    bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100
+    dark:bg-amber-950/30 dark:text-amber-400 dark:border-amber-800/50 dark:hover:bg-amber-950/50
+    transition-colors'
 >
   <slot />
 </div>

--- a/src/components/Posts.astro
+++ b/src/components/Posts.astro
@@ -14,23 +14,22 @@ const { posts } = Astro.props as Props;
   <div class='flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800/60'>
     {
       posts.map(({ data, body, slug }) => (
-        <a
-          href={`/blog/${slug}`}
-          class='group block py-6 pl-0 border-l-2 border-transparent hover:border-brand hover:pl-4 transition-all duration-200'
-        >
-          <div class='flex flex-col gap-1.5'>
-            <h3 class='text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors leading-snug'>
-              {data.title}
-            </h3>
-            <p class='text-xs font-mono text-zinc-400 dark:text-zinc-500'>
-              {formatDate(data.datePublished)} · {formatReadingTime(calculateReadingTime(body))}
-            </p>
-            <p class='text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-2'>
-              {data.excerpt}
-            </p>
-            <Tags tags={data.tags} />
-          </div>
-        </a>
+        <div class='group py-6 pl-0 border-l-2 border-transparent hover:border-brand hover:pl-4 transition-all duration-200'>
+          <a href={`/blog/${slug}`} class='block'>
+            <div class='flex flex-col gap-1.5'>
+              <h3 class='text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors leading-snug'>
+                {data.title}
+              </h3>
+              <p class='text-xs font-mono text-zinc-400 dark:text-zinc-500'>
+                {formatDate(data.datePublished)} · {formatReadingTime(calculateReadingTime(body))}
+              </p>
+              <p class='text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-2'>
+                {data.excerpt}
+              </p>
+            </div>
+          </a>
+          <Tags tags={data.tags} />
+        </div>
       ))
     }
   </div>

--- a/src/components/Posts.astro
+++ b/src/components/Posts.astro
@@ -1,9 +1,7 @@
 ---
 import Tags from '@components/Tags.astro';
-import { formatDate } from '@util/formatter';
+import { formatDate, calculateReadingTime, formatReadingTime } from '@util/formatter';
 import type { CollectionEntry } from 'astro:content';
-import ContentCard from './ContentCard.astro';
-import ReadingTime from './ReadingTime.astro';
 
 interface Props {
   posts: CollectionEntry<'blog'>[];
@@ -12,22 +10,28 @@ interface Props {
 const { posts } = Astro.props as Props;
 ---
 
-<div class='mt-8 flex flex-col gap-4 px-5 max-w-xl mx-auto md:max-w-4xl'>
-  {
-    posts.map(({ data, body, slug }) => (
-      <ContentCard>
-        <a href={`/blog/${slug}`}>
-          <h3 class='font-sans'>{data.title}</h3>
-          <div class='flex space-x-2 items-start'>
-            <p class='text-sm mb-2 text-gray-700 dark:text-zinc-300'>
-              {formatDate(data.datePublished)}
+<div class='w-full max-w-3xl mx-auto px-8 md:px-12 pb-16 mt-8'>
+  <div class='flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800/60'>
+    {
+      posts.map(({ data, body, slug }) => (
+        <a
+          href={`/blog/${slug}`}
+          class='group block py-6 pl-0 border-l-2 border-transparent hover:border-brand hover:pl-4 transition-all duration-200'
+        >
+          <div class='flex flex-col gap-1.5'>
+            <h3 class='text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors leading-snug'>
+              {data.title}
+            </h3>
+            <p class='text-xs font-mono text-zinc-400 dark:text-zinc-500'>
+              {formatDate(data.datePublished)} · {formatReadingTime(calculateReadingTime(body))}
             </p>
-            <ReadingTime html={body} />
+            <p class='text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-2'>
+              {data.excerpt}
+            </p>
+            <Tags tags={data.tags} />
           </div>
-          <p class='text-gray-700 dark:text-zinc-300'>{data.excerpt}</p>
         </a>
-        <Tags tags={data.tags} />
-      </ContentCard>
-    ))
-  }
+      ))
+    }
+  </div>
 </div>

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -22,23 +22,22 @@ const recentPosts = allPosts
   <div class='flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800/60'>
     {
       recentPosts.map(({ data, body, slug }) => (
-        <a
-          href={`/blog/${slug}`}
-          class='group block py-6 pl-0 border-l-2 border-transparent hover:border-brand hover:pl-4 transition-all duration-200'
-        >
-          <div class='flex flex-col gap-1.5'>
-            <h3 class='text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors leading-snug'>
-              {data.title}
-            </h3>
-            <p class='text-xs font-mono text-zinc-400 dark:text-zinc-500'>
-              {formatDate(data.datePublished)} · {formatReadingTime(calculateReadingTime(body))}
-            </p>
-            <p class='text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-2'>
-              {data.excerpt}
-            </p>
-            <Tags tags={data.tags} />
-          </div>
-        </a>
+        <div class='group py-6 pl-0 border-l-2 border-transparent hover:border-brand hover:pl-4 transition-all duration-200'>
+          <a href={`/blog/${slug}`} class='block'>
+            <div class='flex flex-col gap-1.5'>
+              <h3 class='text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors leading-snug'>
+                {data.title}
+              </h3>
+              <p class='text-xs font-mono text-zinc-400 dark:text-zinc-500'>
+                {formatDate(data.datePublished)} · {formatReadingTime(calculateReadingTime(body))}
+              </p>
+              <p class='text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-2'>
+                {data.excerpt}
+              </p>
+            </div>
+          </a>
+          <Tags tags={data.tags} />
+        </div>
       ))
     }
   </div>

--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -1,8 +1,6 @@
 ---
-import { formatDate } from '@util/formatter';
+import { formatDate, calculateReadingTime, formatReadingTime } from '@util/formatter';
 import { getCollection } from 'astro:content';
-import ContentCard from './ContentCard.astro';
-import ReadingTime from './ReadingTime.astro';
 import Tags from './Tags.astro';
 
 const allPosts = await getCollection('blog');
@@ -16,27 +14,42 @@ const recentPosts = allPosts
   .slice(0, 4);
 ---
 
-<div
-  class='flex flex-col justify-center items-start p-5 max-w-4xl m-auto md:mt-8 space-y-8'
->
-  <h2 class='text-left font-bold'>Writing</h2>
-  {
-    recentPosts.map(({ data, body, slug }) => (
-      <div class='w-full'>
-        <ContentCard>
-          <a href={`/blog/${slug}`}>
-            <h3 class='font-sans'>{data.title}</h3>
-            <div class='flex space-x-2 items-start'>
-              <p class='text-sm mb-2 text-gray-700 dark:text-zinc-400'>
-                {formatDate(data.datePublished)}
-              </p>
-              <ReadingTime html={body} />
-            </div>
-            <p class='text-gray-700 dark:text-zinc-400'>{data.excerpt}</p>
-          </a>
-          <Tags tags={data.tags} />
-        </ContentCard>
-      </div>
-    ))
-  }
+<div class='w-full max-w-3xl mx-auto px-8 md:px-12 pb-16'>
+  <p class='text-xs font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500 mb-6'>
+    Writing
+  </p>
+
+  <div class='flex flex-col divide-y divide-zinc-100 dark:divide-zinc-800/60'>
+    {
+      recentPosts.map(({ data, body, slug }) => (
+        <a
+          href={`/blog/${slug}`}
+          class='group block py-6 pl-0 border-l-2 border-transparent hover:border-brand hover:pl-4 transition-all duration-200'
+        >
+          <div class='flex flex-col gap-1.5'>
+            <h3 class='text-base font-semibold text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-200 transition-colors leading-snug'>
+              {data.title}
+            </h3>
+            <p class='text-xs font-mono text-zinc-400 dark:text-zinc-500'>
+              {formatDate(data.datePublished)} · {formatReadingTime(calculateReadingTime(body))}
+            </p>
+            <p class='text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed line-clamp-2'>
+              {data.excerpt}
+            </p>
+            <Tags tags={data.tags} />
+          </div>
+        </a>
+      ))
+    }
+  </div>
+
+  <div class='mt-6'>
+    <a
+      href='/blog'
+      class='text-sm font-medium transition-colors'
+      style='color: hsl(var(--brand))'
+    >
+      View all writing →
+    </a>
+  </div>
 </div>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -9,39 +9,38 @@ const pathName = `/${Astro.request.url.split('/')[3]}`;
 ---
 
 <div
-  class='hidden sm:block fixed h-full text-zinc-700 bg-zinc-100 w-72 p-4 dark:bg-zinc-900/75 dark:text-zinc-200'
+  class='hidden sm:flex flex-col fixed h-full w-64 border-r border-zinc-200 dark:border-zinc-800 bg-background p-5 text-zinc-700 dark:text-zinc-300'
 >
-  <div class='flex justify-between items-center font-bold uppercase mb-4'>
-    <!-- TODO: Add logo here -->
-    <span>David Neuman</span>
+  <div class='flex justify-between items-center mb-6'>
+    <span class='text-xs font-mono font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-400'>David Neuman</span>
     <ThemeToggle client:only='react' />
   </div>
-  <div class='flex flex-col space-y-2'>
+  <nav class='flex flex-col space-y-0.5'>
     {
       navItems.map(({ href, name, popOut, Icon }, idx) => (
         <a target={popOut ? '_blank' : '_self'} href={href}>
           <div
             class={cn(
-              'cursor-pointer p-2 rounded hover:bg-zinc-200/80 hover:shadow dark:hover:bg-zinc-800/80',
-              pathName === href && 'bg-white shadow dark:bg-zinc-800/75',
+              'group cursor-pointer px-3 py-2 rounded-md flex justify-between items-center transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800/60',
+              pathName === href
+                ? 'border-l-2 border-brand bg-zinc-50 dark:bg-zinc-800/40 text-zinc-900 dark:text-zinc-100'
+                : 'border-l-2 border-transparent',
             )}
           >
-            <div class='flex justify-between'>
-              <div class='flex gap-2 items-center'>
-                <Icon className='w-4 h-4' />
-                <span>{name}</span>
-              </div>
-              <span class='flex items-center justify-center text-xs h-4 w-4 p-2.5 text-zinc-400 bg-zinc-300/30 dark:bg-zinc-700'>
-                {idx + 1}
-              </span>
+            <div class='flex gap-2.5 items-center'>
+              <Icon className='w-3.5 h-3.5 text-zinc-400 dark:text-zinc-500' />
+              <span class='text-sm'>{name}</span>
             </div>
+            <span class='font-mono text-[10px] text-zinc-400 dark:text-zinc-600'>
+              {idx + 1}
+            </span>
           </div>
         </a>
       ))
     }
-  </div>
+  </nav>
 
-  <div class='border border-b border-zinc-200 my-4 dark:border-zinc-700'></div>
+  <div class='border-t border-zinc-200 dark:border-zinc-800 my-4'></div>
 
   <ContactDialog openWithSlash client:only='react' />
 </div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -87,10 +87,10 @@ const { title = DefaultSEO.title, description = DefaultSEO.description } =
 <SEO title={title} description={description} />
 
 <div
-  class='flex flex-col sm:flex-row min-h-screen dark:bg-zinc-950 dark:text-gray-100 selection:bg-zinc-950 selection:text-white dark:selection:bg-zinc-800'
+  class='flex flex-col sm:flex-row min-h-screen bg-background text-foreground antialiased selection:bg-zinc-900 selection:text-white dark:selection:bg-zinc-100 dark:selection:text-zinc-900'
 >
   <Sidebar />
-  <div class='sm:ml-72 flex flex-col flex-1 items-center'>
+  <div class='sm:ml-64 flex flex-col flex-1 items-start'>
     <slot />
   </div>
   <FooterNav />

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -1,9 +1,8 @@
 ---
-import { formatDate } from '@util/formatter';
+import { formatDate, calculateReadingTime, formatReadingTime } from '@util/formatter';
 import BaseLayout from './BaseLayout.astro';
 import { Image } from 'astro:assets';
 import Tags from '@components/Tags.astro';
-import ReadingTime from '@components/ReadingTime.astro';
 import type { CollectionEntry } from 'astro:content';
 
 interface Props {
@@ -13,46 +12,50 @@ interface Props {
 
 const { frontmatter, rawContent } = Astro.props as Props;
 
-const hmtl = rawContent();
+const html = rawContent();
+const readingTime = formatReadingTime(calculateReadingTime(html));
 ---
 
-<BaseLayout title={`${frontmatter.title} - <David Neuman />`}>
-  <article
-    class='flex flex-col justify-center max-w-2xl mx-auto w-full mt-8 px-8 md:px-0'
-  >
-    <h1
-      class='text-3xl font-bold mb-2 text-center md:text-5xl md:leading-tight'
-    >
-      {frontmatter.title}
-    </h1>
-    <div class='flex justify-between w-full'>
-      <div class='flex p-4 items-center'>
+<BaseLayout title={`${frontmatter.title} - David Neuman`}>
+  <article class='w-full max-w-3xl mx-auto px-8 md:px-12 mt-10 mb-20'>
+    <!-- Article header -->
+    <header class='mb-10'>
+      <h1
+        class='text-3xl md:text-4xl font-bold tracking-tight leading-tight text-zinc-900 dark:text-zinc-100 mb-4'
+      >
+        {frontmatter.title}
+      </h1>
+      <div class='flex items-center gap-3'>
         <Image
-          class='rounded-full inline-block h-8 w-8 mr-2'
+          class='rounded-full h-7 w-7'
           src='https://avatars.githubusercontent.com/u/42482170?v=4'
           format={'webp'}
-          width={32}
-          height={32}
+          width={28}
+          height={28}
           alt='An avatar of David Neuman'
         />
-        <div class='mr-4 text-xs md:text-base'>
-          {`David Neuman // ${formatDate(frontmatter.datePublished)}`}
-        </div>
+        <span class='text-sm font-mono text-zinc-400 dark:text-zinc-500'>
+          David Neuman · {formatDate(frontmatter.datePublished)} · {readingTime}
+        </span>
       </div>
-      <ReadingTime html={hmtl} />
-    </div>
+    </header>
+
+    <!-- Feature image -->
     <Image
       src={frontmatter.featureImage}
       alt='Feature image'
-      class='mb-[1.2em]'
+      class='rounded-lg mb-10 w-full'
       width={2200}
       height={1080}
     />
-    <main class='prose dark:prose-dark'>
-      <!-- Markdown content is inserted here. -->
+
+    <!-- Prose content -->
+    <main class='prose prose-zinc dark:prose-dark prose-lg max-w-none'>
       <slot />
     </main>
-    <div class='flex justify-center md:block mb-8'>
+
+    <!-- Tags -->
+    <div class='mt-10 pt-8 border-t border-zinc-200 dark:border-zinc-800'>
       <Tags tags={frontmatter.tags} />
     </div>
   </article>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,11 +7,12 @@ const aboutHtml = await about[0].compiledContent();
 ---
 
 <BaseLayout title='About - <David Neuman />'>
-  <Header textAlign='center'>
-    <h1>About</h1>
+  <Header textAlign='left'>
+    <p class='text-xs font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500 mb-1'>About me</p>
+    <h1 class='text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100'>About</h1>
   </Header>
   <div
-    class='flex flex-col justify-center items-center max-w-2xl mx-auto p-8 space-y-8'
+    class='flex flex-col justify-center items-start max-w-3xl mx-auto px-8 md:px-12 py-8 space-y-8'
   >
     <img class='dynamic-image' />
     <main

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -14,8 +14,9 @@ const posts = allPosts
 ---
 
 <BaseLayout title='Writing - <David Neuman />'>
-  <Header textAlign='center'>
-    <h1>Writing</h1>
+  <Header textAlign='left'>
+    <p class='text-xs font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500 mb-1'>All posts</p>
+    <h1 class='text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100'>Writing</h1>
   </Header>
   <Posts posts={posts} />
 </BaseLayout>

--- a/src/pages/books.astro
+++ b/src/pages/books.astro
@@ -9,9 +9,10 @@ const books = getBooks();
 ---
 
 <BaseLayout title='Books - <David Neuman />'>
-  <Header textAlign='center'>
-    <h1 class='text-6xl font-bold mb-2'>Books</h1>
-    <p>A list of books that I've enjoyed recently.</p>
+  <Header textAlign='left'>
+    <p class='text-xs font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500 mb-1'>Reading list</p>
+    <h1 class='text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100 mb-1'>Books</h1>
+    <p class='text-sm text-zinc-500 dark:text-zinc-400'>A list of books that I've enjoyed recently.</p>
   </Header>
   <div class='container p-5 my-10 mx-auto'>
     <div class='grid gap-4 mb-8 mx-auto md:grid-cols-2 md:gap-8 xl:grid-cols-3'>

--- a/src/pages/resources.astro
+++ b/src/pages/resources.astro
@@ -11,8 +11,9 @@ const collections = await getCollections();
 <BaseLayout title='Resources - <David Neuman />'>
   <div class='flex flex-col p-8'>
     <div class='flex flex-col gap-8'>
-      <Header>
-        <h1 class='text-left'>Resources</h1>
+      <Header textAlign='left'>
+        <p class='text-xs font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500 mb-1'>Curated links</p>
+        <h1 class='text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100'>Resources</h1>
       </Header>
       <p class='max-w-xl leading-7 text-zinc-700/75 dark:text-zinc-400'>
         A collection of websites, tools, and portfolios that I find useful or

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,30 +2,6 @@
 @import 'tailwindcss';
 
 @layer base {
-  h1 {
-    @apply text-6xl font-bold;
-  }
-
-  h2 {
-    @apply text-5xl font-bold;
-  }
-
-  h3 {
-    @apply text-4xl font-bold;
-  }
-
-  h4 {
-    @apply text-3xl font-bold;
-  }
-
-  h5 {
-    @apply text-2xl font-bold;
-  }
-
-  h6 {
-    @apply text-xl font-bold;
-  }
-
   :root {
     font-size: 16px;
 
@@ -58,36 +34,44 @@
     --ring: 240 10% 3.9%;
 
     --radius: 0.5rem;
+
+    /* Brand accent — warm amber */
+    --brand: 35 95% 50%;
+    --brand-foreground: 0 0% 100%;
   }
 
   .dark {
-    --background: 240 10% 3.9%;
+    --background: 0 0% 5%;
     --foreground: 0 0% 98%;
 
-    --card: 240 10% 3.9%;
+    --card: 0 0% 5%;
     --card-foreground: 0 0% 98%;
 
-    --popover: 240 10% 3.9%;
+    --popover: 0 0% 5%;
     --popover-foreground: 0 0% 98%;
 
     --primary: 0 0% 98%;
     --primary-foreground: 240 5.9% 10%;
 
-    --secondary: 240 3.7% 15.9%;
+    --secondary: 240 3.7% 13%;
     --secondary-foreground: 0 0% 98%;
 
-    --muted: 240 3.7% 15.9%;
+    --muted: 240 3.7% 13%;
     --muted-foreground: 240 5% 64.9%;
 
-    --accent: 240 3.7% 15.9%;
+    --accent: 240 3.7% 13%;
     --accent-foreground: 0 0% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
 
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
+    --border: 0 0% 12%;
+    --input: 0 0% 12%;
     --ring: 240 4.9% 83.9%;
+
+    /* Brand accent — slightly brighter in dark mode */
+    --brand: 35 95% 58%;
+    --brand-foreground: 0 0% 5%;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,10 @@ export default {
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        brand: {
+          DEFAULT: 'hsl(var(--brand))',
+          foreground: 'hsl(var(--brand-foreground))',
+        },
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',
@@ -60,20 +64,37 @@ export default {
       typography: (theme) => ({
         DEFAULT: {
           css: {
-            color: theme('colors.gray.900'),
+            color: theme('colors.zinc.800'),
+            fontSize: '1.0625rem',
+            lineHeight: '1.85',
+            maxWidth: '68ch',
             th: {
-              color: theme('colors.gray.900'),
+              color: theme('colors.zinc.800'),
+            },
+            'h1, h2, h3, h4, h5, h6': {
+              color: theme('colors.zinc.900'),
+              fontWeight: '700',
+              letterSpacing: '-0.02em',
             },
             a: {
-              'text-decoration': 'none',
-              color: theme('colors.blue.800'),
-              'background-color': theme('colors.zinc.100'),
+              'text-decoration': 'underline',
+              'text-decoration-color': theme('colors.amber.400'),
+              'text-underline-offset': '3px',
+              color: theme('colors.amber.700'),
+              'background-color': 'transparent',
+              'font-weight': '500',
+              transition: 'color 0.15s ease',
+            },
+            'a:hover': {
+              color: theme('colors.amber.600'),
             },
             code: {
-              'background-color': theme('colors.gray.100'),
-              'border-radius': '3px',
-              padding: '3px',
-              'font-weight': 600,
+              'background-color': theme('colors.zinc.100'),
+              'border-radius': '4px',
+              padding: '2px 5px',
+              'font-weight': '500',
+              'font-size': '0.875em',
+              border: `1px solid ${theme('colors.zinc.200')}`,
             },
             'code::before': {
               content: '""',
@@ -81,44 +102,70 @@ export default {
             'code::after': {
               content: '""',
             },
+            pre: {
+              'background-color': theme('colors.zinc.950'),
+              border: `1px solid ${theme('colors.zinc.800')}`,
+              'border-radius': '8px',
+            },
+            'pre code': {
+              'background-color': 'transparent',
+              border: 'none',
+              padding: '0',
+            },
+            blockquote: {
+              'border-left-color': theme('colors.amber.400'),
+              color: theme('colors.zinc.600'),
+              'font-style': 'normal',
+            },
             'figure figcaption': {
-              color: theme('colors.gray.700'),
+              color: theme('colors.zinc.500'),
               'text-align': 'center',
+              'font-size': '0.8125rem',
             },
             figcaption: {
-              color: theme('colors.gray.700'),
+              color: theme('colors.zinc.500'),
               'text-align': 'center',
+              'font-size': '0.8125rem',
             },
           },
         },
         dark: {
           css: {
             color: theme('colors.zinc.300'),
+            'h1, h2, h3, h4, h5, h6': {
+              color: theme('colors.zinc.100'),
+            },
             th: {
               color: theme('colors.zinc.300'),
             },
             a: {
-              color: theme('colors.blue.500'),
-              'background-color': theme('colors.zinc.800'),
+              color: theme('colors.amber.400'),
+              'text-decoration-color': theme('colors.amber.600'),
+              'background-color': 'transparent',
             },
-            'h1,h2,h3,h4': {
-              color: theme('colors.zinc.200'),
+            'a:hover': {
+              color: theme('colors.amber.300'),
             },
             strong: {
               color: theme('colors.zinc.200'),
             },
             blockquote: {
-              color: theme('colors.zinc.200'),
+              color: theme('colors.zinc.400'),
+              'border-left-color': theme('colors.amber.500'),
             },
             code: {
               color: theme('colors.zinc.200'),
-              'background-color': '#0d1117',
+              'background-color': theme('colors.zinc.900'),
+              border: `1px solid ${theme('colors.zinc.700')}`,
             },
             pre: {
-              code: {
-                'background-color': 'inherit',
-                color: 'inherit',
-              },
+              'background-color': '#0d1117',
+              border: `1px solid ${theme('colors.zinc.800')}`,
+            },
+            'pre code': {
+              'background-color': 'transparent',
+              border: 'none',
+              color: 'inherit',
             },
             'figure figcaption': {
               color: theme('colors.zinc.500'),


### PR DESCRIPTION
- Add warm amber brand token (hsl 35 95% 50%) to colour system
- Tighten dark mode to true near-black (#0d0d0d equivalent)
- Sidebar: hairline right border, amber active indicator, monospace shortcut labels
- Hero: clean editorial layout, updated tagline for agentic/human content focus
- Blog post layout: wider column (max-w-3xl), clean header with mono meta, prose-lg
- Recent posts: list-style with amber hover left-border, mono date/readtime
- Pills/tags: amber accent treatment throughout
- Footer nav: backdrop-blur + hairline top border
- Typography: amber links, improved prose spacing, better code blocks

https://claude.ai/code/session_01HSqLDjAWJHeK8FJuoPdVGK